### PR TITLE
Remove duplicated firebase-auth.js importing

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,6 @@
 </div>
 
 <script src="https://www.gstatic.com/firebasejs/4.5.0/firebase.js"></script>
-<script src="https://www.gstatic.com/firebasejs/4.5.0/firebase-auth.js"></script>
 <script src="https://www.gstatic.com/firebasejs/4.5.0/firebase-firestore.js"></script>
 
 <script src="/third_party/lib/navigo.js"></script>


### PR DESCRIPTION
Following the Firestore Web Codelab, in [step 3](https://codelabs.developers.google.com/codelabs/firestore-web/#3) I'm getting this uncaught exception in DevTools console:
>Firebase: Firebase service named 'auth' already registered (app/duplicate-service).

That's probably because `firebase.js` already ships the auth service, so we don't need to import `firebase-auth.js`.