### PR TITLE
Fixed duplicate-service error and timestamps warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,8 @@
   </aside>
 </div>
 
-<script src="/__/firebase/5.5.0/firebase.js"></script>
+<script src="/__/firebase/5.5.0/firebase-app.js"></script>
+<script src="/__/firebase/5.5.0/firebase-auth.js"></script>
 <script src="/__/firebase/5.5.0/firebase-firestore.js"></script>
 <script src="/__/firebase/init.js"></script>
 

--- a/scripts/FriendlyEats.js
+++ b/scripts/FriendlyEats.js
@@ -28,6 +28,8 @@ function FriendlyEats() {
 
   this.dialogs = {};
 
+  firebase.firestore().settings({ timestampsInSnapshots: true });
+
   var that = this;
   firebase.auth().signInAnonymously().then(function() {
     that.initTemplates();


### PR DESCRIPTION
I fixed duplicate-service error and timestamps warning.

### duplicate-service error 

`Firebase service named 'firestore' already registered (app/duplicate-service).`

### timestamps warning

```
The behavior for Date objects stored in Firestore is going to change
AND YOUR APP MAY BREAK.
To hide this warning and ensure your app does not break, you need to add the
following code to your app before calling any other Cloud Firestore methods:
  const firestore = firebase.firestore();
  const settings = {/* your settings... */ timestampsInSnapshots: true};
  firestore.settings(settings);
```
