### PR TITLE
Set specific version for MDC js and css

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
 
   <!-- Material Design Components -->
   <link rel="stylesheet"
-  href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css">
-  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.js"></script>
+  href="https://unpkg.com/material-components-web@0.39.0/dist/material-components-web.min.css">
+  <script src="https://unpkg.com/material-components-web@0.39.0/dist/material-components-web.js"></script>
 
   <!-- App Styling -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en">


### PR DESCRIPTION
Version 4.0.0 of material-components-web has BC breaks that cause this to stop working. 0.39.0 does work.

Requires reworking how MDCDialog is setup and initialised. MCDDialog.show() is now .open() but just changing the call in FriendlyEats.View.js isn't enough. Believe it needs all the lists shown in the dialog to be updated. I'm not familiar enough with MDC (nor will I be) to do all the updates.