### PR TITLE
Update firestore.indexes.json to use the new index API format.

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,60 +1,117 @@
 {
   "indexes": [
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "city", "mode": "ASCENDING" },
-        { "fieldPath": "avgRating", "mode": "DESCENDING" }
+        {
+          "fieldPath": "price",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "avgRating",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "category", "mode": "ASCENDING" },
-        { "fieldPath": "avgRating", "mode": "DESCENDING" }
+        {
+          "fieldPath": "city",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "avgRating",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "price", "mode": "ASCENDING" },
-        { "fieldPath": "avgRating", "mode": "DESCENDING" }
+        {
+          "fieldPath": "price",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "numRatings",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "city", "mode": "ASCENDING" },
-        { "fieldPath": "numRatings", "mode": "DESCENDING" }
+        {
+          "fieldPath": "city",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "numRatings",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "category", "mode": "ASCENDING" },
-        { "fieldPath": "numRatings", "mode": "DESCENDING" }
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "avgRating",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "price", "mode": "ASCENDING" },
-        { "fieldPath": "numRatings", "mode": "DESCENDING" }
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "price",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "city", "mode": "ASCENDING" },
-        { "fieldPath": "price", "mode": "ASCENDING" }
+        {
+          "fieldPath": "city",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "price",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
-      "collectionId": "restaurants",
+      "collectionGroup": "restaurants",
+      "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "category", "mode": "ASCENDING" },
-        { "fieldPath": "price", "mode": "ASCENDING" }
+        {
+          "fieldPath": "category",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "numRatings",
+          "order": "DESCENDING"
+        }
       ]
     }
-  ]
+  ],
+  "fieldOverrides": []
 }


### PR DESCRIPTION
While running through the external codelab during the firestore summit the index upload snippets spits out this warning:

firestore: your indexes indexes are specified in the v1beta1 API format. Please upgrade to the new index API format by running firebase firestore:indexes again and saving the result.                                                                                             

I've generated the new format and edited the file accordingly.