### PR TITLE
Remove timestampInSnapshots setting

### DIFF
--- a/scripts/FriendlyEats.js
+++ b/scripts/FriendlyEats.js
@@ -28,8 +28,6 @@ function FriendlyEats() {
 
   this.dialogs = {};
 
-  firebase.firestore().settings({ timestampsInSnapshots: true });
-
   var that = this;
   firebase.auth().signInAnonymously().then(function() {
     that.initTemplates();


### PR DESCRIPTION
Firestore now displays a warning if the property is set:

2019-04-19T02:53:48.347Z]  @firebase/firestore: Firestore (5.9.4): 
  The timestampsInSnapshots setting now defaults to true and you no
  longer need to explicitly set it. In a future release, the setting
  will be removed entirely and so it is recommended that you remove it
  from your firestore.settings() call now.