### PR TITLE
Fix a broken link to the LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Follow the [Cloud Firestore Web Codelab][codelab] to set up this sample.
 
 ## License
 
-© Google, 2018. Licensed under an [Apache-2](../LICENSE) license.
+© Google, 2018. Licensed under an [Apache-2](./LICENSE) license.
 
 ## Build Status
 


### PR DESCRIPTION
Fix the bottom link to Apache-2 on README.md, which seems to be broken.