### PR TITLE
fix bug in auth

### DIFF
--- a/nextjs-end/src/lib/firebase/auth.js
+++ b/nextjs-end/src/lib/firebase/auth.js
@@ -22,7 +22,7 @@ export async function signInWithGoogle() {
 
 export async function signOut() {
   try {
-    return auth.signOut();
+    await auth.signOut();
   } catch (error) {
     console.error("Error signing out with Google", error);
   }


### PR DESCRIPTION
Without await, this will never actually catch the error in the try/catch block, but return the (rejected) promise.